### PR TITLE
fix undefined buffer variable causing an exception in web builds

### DIFF
--- a/Runtime/Internal/WebSocket.jslib
+++ b/Runtime/Internal/WebSocket.jslib
@@ -153,17 +153,11 @@ var LibraryWebSocket =
             if (webSocketState.errorCallback === null)
                 return;
 
-            try
-            {
-                if (webSocketState.haveDynCall)
-                    Module.dynCall_vi(webSocketState.errorCallback, instanceId);
-                else
-                    {{{ makeDynCall('vi', 'webSocketState.errorCallback') }}}(instanceId);
-            }
-            finally
-            {
-                _free(buffer);
-            }
+			if (webSocketState.haveDynCall)
+				Module.dynCall_vi(webSocketState.errorCallback, instanceId);
+			else
+				{{{ makeDynCall('vi', 'webSocketState.errorCallback') }}}(instanceId);
+            
         };
 
         instance.ws.onclose = function(event)


### PR DESCRIPTION
When currently building and running on Unity Web platform, an exception is thrown when the connection to server fails for whatever reason.

It's caused by the instance.ws.onerror jslib function. Calling _free on the buffer variable won't work, as it doesn't exist in that scope. It does exist in other similar functions like instance.ws.onmessage or instance.ws.onopen, so it's probably just a little copy-paste oversight?

Anyways, this PR should fix exceptions being thrown when trying to connect to a server that's currently down/unreachable inside the browser/on Web platform builds.