### PR TITLE
Fix incorrect handling of server-initiated closures in DotNet impl

### DIFF
--- a/Runtime/WebSocketConnection.cs
+++ b/Runtime/WebSocketConnection.cs
@@ -301,11 +301,7 @@ namespace MikeSchweitzer.WebSocket
             if (_webSocket == null)
                 return;
 
-            if (_cancellationTokenSource.IsCancellationRequested)
-                _webSocket.Cancel();
-            else
-                await _webSocket.CloseAsync();
-
+            await _webSocket.CloseAsync();
             await _connectTask;
 
             OnWebSocketShutdown();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.mikeschweitzer.websocket",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "displayName": "WebSocket Client",
   "description": "Simple, flexible WebSocket client. Add the WebSocketConnection MonoBehaviour anywhere in your scene.",
   "license": "Apache 2.0",


### PR DESCRIPTION
Fix #23, incorrect handling of server-initiated closures. Refactor DotNet Receive loop to be more robust and easier to read. Also fixes a number of minor bugs clearing out and setting states in the DotNet path.